### PR TITLE
Remove AWS Max Version Limitation

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.13"
 
   required_providers {
-    aws        = ">= 3.13, < 4.0"
+    aws        = ">= 3.13"
     helm       = ">= 1.0, < 3.0"
     kubernetes = ">= 1.10.0, < 3.0.0"
   }


### PR DESCRIPTION
Currently this module blocks usage of the > 4.0 versions of the AWS provider.
## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)

## Checklist


- [X] I have read the CONTRIBUTING.md doc.
- [X] I have added necessary documentation (if appropriate).
- [X] Any dependent changes have been merged and published in downstream modules.

## Further comments

This is required for use of the new AWS modules. 