### PR TITLE
Fixing problem when create_namespace == false

### DIFF
--- a/helm.tf
+++ b/helm.tf
@@ -5,7 +5,7 @@ resource "helm_release" "external_secrets" {
   chart      = var.helm_chart_release_name
   repository = var.helm_chart_repo
   version    = var.helm_chart_version
-  namespace  = kubernetes_namespace.external_secrets[0].id
+  namespace  = var.create_namespace ? kubernetes_namespace.external_secrets[0].id : var.namespace
 
   set {
     name  = "serviceAccount.annotations.eks\\.amazonaws\\.com/role-arn"


### PR DESCRIPTION
Enables using an existing namespace. Fixes #17 


## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the CONTRIBUTING.md doc.
- [x] I have added necessary documentation (if appropriate).
- [x] Any dependent changes have been merged and published in downstream modules.

## Further comments

The idea is to deploy external-secrets to an existing namespace so we can reference the `external-secrets` serviceAccount in secretStores in namespaces other than `external-secrets`. According to https://pkg.go.dev/github.com/external-secrets/external-secrets/apis/meta/v1#ServiceAccountSelector the namespace cannot be used if "referent" is not cluster-scoped.